### PR TITLE
Remove allocation in hashDigest to improve hashing speed

### DIFF
--- a/hashring.go
+++ b/hashring.go
@@ -142,11 +142,11 @@ func (h *HashRing) GenKey(key string) HashKey {
 func (h *HashRing) GetNodes(stringKey string, size int) (nodes []string, ok bool) {
 	pos, ok := h.GetNodePos(stringKey)
 	if !ok {
-		return []string{}, false
+		return nil, false
 	}
 
 	if size > len(h.nodes) {
-		return []string{}, false
+		return nil, false
 	}
 
 	returnedValues := make(map[string]bool, size)
@@ -268,8 +268,6 @@ func hashVal(bKey []byte) HashKey {
 		(HashKey(bKey[0])))
 }
 
-func hashDigest(key string) []byte {
-	m := md5.New()
-	m.Write([]byte(key))
-	return m.Sum(nil)
+func hashDigest(key string) [md5.Size]byte {
+	return md5.Sum([]byte(key))
 }

--- a/hashring_test.go
+++ b/hashring_test.go
@@ -476,3 +476,27 @@ func BenchmarkHashes(b *testing.B) {
 		hashRing.GetNodes(o.key, 2)
 	}
 }
+
+func BenchmarkHashesSingle(b *testing.B) {
+	nodes := []string{"a", "b", "c", "d", "e", "f", "g"}
+	hashRing := New(nodes)
+	tt := []struct {
+		key   string
+		nodes []string
+	}{
+		{"test", []string{"a", "b"}},
+		{"test", []string{"a", "b"}},
+		{"test1", []string{"b", "d"}},
+		{"test2", []string{"f", "b"}},
+		{"test3", []string{"f", "c"}},
+		{"test4", []string{"c", "b"}},
+		{"test5", []string{"f", "a"}},
+		{"aaaa", []string{"b", "a"}},
+		{"bbbb", []string{"f", "a"}},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		o := tt[i%len(tt)]
+		hashRing.GetNode(o.key)
+	}
+}


### PR DESCRIPTION
Using an constant-sized array rather than a slice lets Go allocate the hash
on the stack rather than the heap when possible.

```
benchmark                   old ns/op     new ns/op     delta
BenchmarkHashes-8           771           497           -35.54%
BenchmarkHashesSingle-8     492           239           -51.42%

benchmark                   old allocs     new allocs     delta
BenchmarkHashes-8           4              1              -75.00%
BenchmarkHashesSingle-8     3              0              -100.00%
```