### PR TITLE
search node in weights map to speed up add/remove check

### DIFF
--- a/hashring.go
+++ b/hashring.go
@@ -81,15 +81,12 @@ func (h *HashRing) generateCircle() {
 			totalWeight += weight
 		} else {
 			totalWeight += 1
+			h.weights[node] = 1
 		}
 	}
 
 	for _, node := range h.nodes {
-		weight := 1
-
-		if _, ok := h.weights[node]; ok {
-			weight = h.weights[node]
-		}
+		weight := h.weights[node]
 
 		factor := math.Floor(float64(40*len(h.nodes)*weight) / float64(totalWeight))
 
@@ -177,10 +174,8 @@ func (h *HashRing) AddWeightedNode(node string, weight int) *HashRing {
 		return h
 	}
 
-	for _, eNode := range h.nodes {
-		if eNode == node {
-			return h
-		}
+	if _, ok := h.weights[node]; ok {
+		return h
 	}
 
 	nodes := make([]string, len(h.nodes), len(h.nodes)+1)
@@ -232,16 +227,16 @@ func (h *HashRing) UpdateWeightedNode(node string, weight int) *HashRing {
 	return hashRing
 }
 func (h *HashRing) RemoveNode(node string) *HashRing {
+	/* if node isn't exist in hashring, don't refresh hashring */
+	if _, ok := h.weights[node]; !ok {
+		return h
+	}
+
 	nodes := make([]string, 0)
 	for _, eNode := range h.nodes {
 		if eNode != node {
 			nodes = append(nodes, eNode)
 		}
-	}
-
-	/* if node isn't exist in hashring, don't refresh hashring */
-	if len(nodes) == len(h.nodes) {
-		return h
 	}
 
 	weights := make(map[string]int)

--- a/hashring_test.go
+++ b/hashring_test.go
@@ -20,6 +20,13 @@ func expectNodes(t *testing.T, hashRing *HashRing, key string, expectedNodes []s
 	}
 }
 
+func expectWeights(t *testing.T, hashRing *HashRing, expectedWeights map[string]int) {
+	weightsEquality := reflect.DeepEqual(hashRing.weights, expectedWeights)
+	if !weightsEquality {
+		t.Error("Weights expected", expectedWeights, "but got", hashRing.weights)
+	}
+}
+
 func expectNodesABC(t *testing.T, hashRing *HashRing) {
 	// Python hash_ring module test case
 	expectNode(t, hashRing, "test", "a")
@@ -158,6 +165,13 @@ func TestAddNode(t *testing.T) {
 	hashRing = hashRing.AddNode("b")
 
 	expectNodesABC(t, hashRing)
+
+	defaultWeights := map[string]int{
+		"a": 1,
+		"b": 1,
+		"c": 1,
+	}
+	expectWeights(t, hashRing, defaultWeights)
 }
 
 func TestAddNode2(t *testing.T) {
@@ -306,6 +320,8 @@ func TestRemoveAddWeightedNode(t *testing.T) {
 	weights["c"] = 1
 	hashRing := NewWithWeights(weights)
 
+	expectWeights(t, hashRing, weights)
+
 	expectNode(t, hashRing, "test", "b")
 	expectNode(t, hashRing, "test", "b")
 	expectNode(t, hashRing, "test1", "b")
@@ -327,6 +343,9 @@ func TestRemoveAddWeightedNode(t *testing.T) {
 	expectNodes(t, hashRing, "bbbb", []string{"a", "b"})
 
 	hashRing = hashRing.RemoveNode("c")
+
+	delete(weights, "c")
+	expectWeights(t, hashRing, weights)
 
 	expectNode(t, hashRing, "test", "b")
 	expectNode(t, hashRing, "test", "b")


### PR DESCRIPTION
Hold the weigths map for both weight-specified and unspecified situation. So we could use weights map to fast search actual node in add/remove check.

Mv the check to the head of `RemoveNode` func. Alloc new nodes slice after passing check.