### PR TITLE
replace Sprintf with FormatInt for performance

### DIFF
--- a/hashring.go
+++ b/hashring.go
@@ -2,9 +2,9 @@ package hashring
 
 import (
 	"crypto/md5"
-	"fmt"
 	"math"
 	"sort"
+	"strconv"
 )
 
 type HashKey uint32
@@ -91,7 +91,7 @@ func (h *HashRing) generateCircle() {
 		factor := math.Floor(float64(40*len(h.nodes)*weight) / float64(totalWeight))
 
 		for j := 0; j < int(factor); j++ {
-			nodeKey := fmt.Sprintf("%s-%d", node, j)
+			nodeKey := node + "-" + strconv.FormatInt(int64(j), 10)
 			bKey := hashDigest(nodeKey)
 
 			for i := 0; i < 3; i++ {

--- a/hashring_test.go
+++ b/hashring_test.go
@@ -519,3 +519,11 @@ func BenchmarkHashesSingle(b *testing.B) {
 		hashRing.GetNode(o.key)
 	}
 }
+
+func BenchmarkNew(b *testing.B) {
+	nodes := []string{"a", "b", "c", "d", "e", "f", "g"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = New(nodes)
+	}
+}


### PR DESCRIPTION
fmt.Sprintf is not performing well

name   old time/op  new time/op  delta
New-4   283µs ± 1%   244µs ± 3%  -13.71%  (p=0.000 n=17+18)