### PR TITLE
Change hashring API to allow not thread-safe hash.Hash

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -13,13 +13,13 @@ func ExampleGetAllNodes() {
 }
 
 func ExampleCustomHashError() {
-	_, err := NewHash(sha1.New()).Use(NewInt64PairHashKey)
+	_, err := NewHash(sha1.New).Use(NewInt64PairHashKey)
 	fmt.Printf("%s", err.Error())
 	// Output: can't use given hash.Hash with given hashKeyFunc: expected 16 bytes, got 20 bytes
 }
 
 func ExampleCustomHash() {
-	hashFunc, _ := NewHash(sha1.New()).FirstBytes(16).Use(NewInt64PairHashKey)
+	hashFunc, _ := NewHash(sha1.New).FirstBytes(16).Use(NewInt64PairHashKey)
 	hashRing := NewWithHash([]string{"node1", "node2", "node3"}, hashFunc)
 	nodes, _ := hashRing.GetNodes("key", hashRing.Size())
 	fmt.Printf("%v", nodes)
@@ -27,7 +27,7 @@ func ExampleCustomHash() {
 }
 
 func ExampleNewHashFunc() {
-	hashFunc, _ := NewHash(sha1.New()).FirstBytes(16).Use(NewInt64PairHashKey)
+	hashFunc, _ := NewHash(sha1.New).FirstBytes(16).Use(NewInt64PairHashKey)
 	fmt.Printf("%v\n", hashFunc([]byte("test")))
 	// Output: &{-6441359348440544599 -8653224871661646820}
 }

--- a/hash.go
+++ b/hash.go
@@ -7,13 +7,24 @@ import (
 
 // HashSum allows to use a builder pattern to create different HashFunc objects.
 // See examples for details.
-type HashSum func([]byte) []byte
+type HashSum struct {
+	functions []func([]byte) []byte
+}
 
-func (r HashSum) Use(
+func (r *HashSum) Use(
 	hashKeyFunc func(bytes []byte) (HashKey, error),
 ) (HashFunc, error) {
-	// check HashSum for errors
-	testResult := r([]byte("test"))
+
+	// build final hash function
+	composed := func(bytes []byte) []byte {
+		for _, f := range r.functions {
+			bytes = f(bytes)
+		}
+		return bytes
+	}
+
+	// check function composition for errors
+	testResult := composed([]byte("test"))
 	_, err := hashKeyFunc(testResult)
 	if err != nil {
 		const msg = "can't use given hash.Hash with given hashKeyFunc"
@@ -22,33 +33,41 @@ func (r HashSum) Use(
 
 	// build HashFunc
 	return func(key []byte) HashKey {
-		bytes := r(key)
-		// ignore error because we already checked HashSum earlier
+		bytes := composed(key)
 		hashKey, err := hashKeyFunc(bytes)
 		if err != nil {
+			// panic because we already checked HashSum earlier
 			panic(fmt.Sprintf("hashKeyFunc failure: %v", err))
 		}
 		return hashKey
 	}, nil
 }
 
-func NewHash(hasher hash.Hash) HashSum {
-	return func(key []byte) []byte {
-		hasher.Reset()
-		hasher.Write(key)
-		return hasher.Sum(nil)
+// NewHash creates a new *HashSum object which can be used to create HashFunc.
+// HashFunc object is thread safe if the hasher argument produces a new hash.Hash 
+// each time. The produced hash.Hash is allowed to be non thread-safe.
+func NewHash(hasher func() hash.Hash) *HashSum {
+	return &HashSum{
+		functions: []func(key []byte) []byte{
+			func(key []byte) []byte {
+				hash := hasher()
+				hash.Write(key)
+				return hash.Sum(nil)
+			},
+		},
 	}
 }
 
-func (r HashSum) FirstBytes(n int) HashSum {
-	return func(bytes []byte) []byte {
-		return r(bytes)[:n]
-	}
+func (r *HashSum) FirstBytes(n int) *HashSum {
+	r.functions = append(r.functions, func(bytes []byte) []byte {
+		return bytes[:n]
+	})
+	return r
 }
 
-func (r HashSum) LastBytes(n int) HashSum {
-	return func(bytes []byte) []byte {
-		result := r(bytes)
-		return result[len(result)-n:]
-	}
+func (r *HashSum) LastBytes(n int) *HashSum {
+	r.functions = append(r.functions, func(bytes []byte) []byte {
+		return bytes[len(bytes)-n:]
+	})
+	return r
 }

--- a/hashring.go
+++ b/hashring.go
@@ -8,7 +8,7 @@ import (
 )
 
 var defaultHashFunc = func() HashFunc {
-	hashFunc, err := NewHash(md5.New()).Use(NewInt64PairHashKey)
+	hashFunc, err := NewHash(md5.New).Use(NewInt64PairHashKey)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create defaultHashFunc: %s", err.Error()))
 	}
@@ -166,6 +166,9 @@ func (h *HashRing) GenKey(key string) HashKey {
 	return h.hashFunc([]byte(key))
 }
 
+// GetNodes iterates over the hash ring and returns the nodes in the order
+// which is determined by the key. GetNodes is thread safe if the hash
+// which was used to configure the hash ring is thread safe.
 func (h *HashRing) GetNodes(stringKey string, size int) (nodes []string, ok bool) {
 	pos, ok := h.GetNodePos(stringKey)
 	if !ok {


### PR DESCRIPTION
NewHash uses the same hash.Hash object every time it's called. That means that you can use hashring object from multiple goroutines only if you specified a thread safe hash.Hash. In other words hashring is thread safe if and only if the provided hash.Hash is thread safe.

This patch fixes this behaviour. Here we create new hash.Hash for every call. 